### PR TITLE
fixed missing required prop onRequestClose warning for Android

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -73,7 +73,6 @@ var CountryPicker = function (_Component) {
     value: function _getCountryName(country) {
       var translation = this.props.translation || 'eng';
       return country.translations[translation] && country.translations[translation].common || country.name.common;
-      xrg;
     }
   }, {
     key: '_orderCountryList',
@@ -227,7 +226,12 @@ var CountryPicker = function (_Component) {
         ),
         _react2.default.createElement(
           _reactNative.Modal,
-          { visible: this.state.modalVisible },
+          {
+            visible: this.state.modalVisible,
+            onRequestClose: function onRequestClose() {
+              return _this6.setState({ modalVisible: false });
+            }
+          },
           _react2.default.createElement(_reactNative.ListView, {
             contentContainerStyle: styles.contentContainer,
             ref: function ref(scrollView) {
@@ -269,7 +273,7 @@ var styles = _reactNative.StyleSheet.create({
     height: _Ratio2.default.getHeightPercent(2.5)
   },
   imgStyle: {
-    resizeMode: 'stretch',
+    resizeMode: 'contain',
     width: 25,
     height: 19,
     borderWidth: 1 / _reactNative.PixelRatio.get(),

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,10 @@ class CountryPicker extends Component {
               source={{uri: CountryFlags[this.state.cca2]}}/>
           </View>
         </TouchableOpacity>
-        <Modal visible={this.state.modalVisible}>
+        <Modal
+          visible={this.state.modalVisible}
+          onRequestClose={() => this.setState({modalVisible: false})}
+        >
           <ListView
             contentContainerStyle={styles.contentContainer}
             ref={(scrollView) => { this._scrollView = scrollView; }}


### PR DESCRIPTION
This PR fixes #12 where a warning is shown since the required prop `onRequestClose` is missing on Android. I added an onRequestClose prop that hides the modal when the back button is pressed on Android. 

The warning should be gone and the hardware back button press should close the modal on Android. 