### PR TITLE
pca/add background view for modal

### DIFF
--- a/examples/Example.js
+++ b/examples/Example.js
@@ -21,6 +21,7 @@ export default class Example extends Component {
       cca2: 'US'
     };
   }
+
   render() {
     return (
       <View style={styles.container}>
@@ -28,7 +29,7 @@ export default class Example extends Component {
           Welcome to Country Picker !
         </Text>
         <CountryPicker
-          onChange={(value)=> this.setState({country: value})}
+          onChange={(value)=> this.setState({country: value, cca2: value.cca2})}
           cca2={this.state.cca2}
           translation='eng'
           closeable

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -27,13 +27,6 @@ class CountryPicker extends Component {
 
   constructor(props) {
     super(props);
-    const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
-    this.state = {
-      cca2: props.cca2,
-      currentCountry: this.getCountry(props.cca2),
-      modalVisible: false,
-      countries: ds.cloneWithRows(this.orderCountryList())
-    };
     this.letters = _
       .range('A'.charCodeAt(0), 'Z'.charCodeAt(0) + 1)
       .map(n => String.fromCharCode(n).substr(0));
@@ -41,11 +34,24 @@ class CountryPicker extends Component {
     // dimensions of country list and window
     this.itemHeight = getHeightPercent(7);
     this.listHeight = countries.length * this.itemHeight;
+
+    this.state = {
+      modalVisible: false,
+      cca2: props.cca2,
+      currentCountry: this.getCountry(props.cca2),
+    };
   }
 
   getCountry({ cca2 }) {
     return _.find(countries, {
       cca2
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      cca2: nextProps.cca2,
+      currentCountry: this.getCountry(nextProps.cca2),
     });
   }
 
@@ -151,6 +157,9 @@ class CountryPicker extends Component {
   }
 
   render() {
+    const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+    const dataSource = ds.cloneWithRows(this.orderCountryList());
+
     return (
       <View>
         <TouchableOpacity
@@ -172,7 +181,7 @@ class CountryPicker extends Component {
           <ListView
             contentContainerStyle={styles.contentContainer}
             ref={scrollView => { this._scrollView = scrollView; }}
-            dataSource={this.state.countries}
+            dataSource={dataSource}
             renderRow={country => this.renderCountry(country)}
             initialListSize={20}
             pageSize={countries.length - 20}

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -166,21 +166,23 @@ class CountryPicker extends Component {
         <Modal
           visible={this.state.modalVisible}
           onRequestClose={() => this.setState({modalVisible: false})}>
-          {
-            this.props.closeable &&
-            <CloseButton onPress={() => this.setState({modalVisible: false})} />
-          }
-          <ListView
-            contentContainerStyle={styles.contentContainer}
-            ref={scrollView => { this._scrollView = scrollView; }}
-            dataSource={dataSource}
-            renderRow={country => this.renderCountry(country)}
-            initialListSize={20}
-            pageSize={countries.length - 20}
-            onLayout={({nativeEvent: { layout: { y: offset} }}) => this.setVisibleListHeight(offset)}
-          />
-          <View style={styles.letters}>
-            {this.letters.map((letter, index) => this.renderLetters(letter, index))}
+          <View style={styles.modalContainer}>
+            {
+              this.props.closeable &&
+              <CloseButton onPress={() => this.setState({modalVisible: false})} />
+            }
+            <ListView
+              contentContainerStyle={styles.contentContainer}
+              ref={scrollView => { this._scrollView = scrollView; }}
+              dataSource={dataSource}
+              renderRow={country => this.renderCountry(country)}
+              initialListSize={20}
+              pageSize={countries.length - 20}
+              onLayout={({nativeEvent: { layout: { y: offset} }}) => this.setVisibleListHeight(offset)}
+            />
+            <View style={styles.letters}>
+              {this.letters.map((letter, index) => this.renderLetters(letter, index))}
+            </View>
           </View>
         </Modal>
       </View>
@@ -189,6 +191,9 @@ class CountryPicker extends Component {
 }
 
 const styles = StyleSheet.create({
+  modalContainer: {
+    backgroundColor: 'white',
+  },
   contentContainer: {
     width: getWidthPercent(100),
     backgroundColor: 'white'


### PR DESCRIPTION
When using the CountryPicker in my app with `closeable` set to `true` , the header and the background color of the country listview is black. This means that the screen doesn't look good and the close button is  not visible (black on black).

The change I am suggesting in this PR is to wrap the content of the Modal in a View for which a style sets the background color to white. 

This doesn't seem to break anything in the existing Example and that is now working in the context of my application.

Thanks.

Pierre