### PR TITLE
fixed calling unsupported method `TouchableNativeFeedback.SelectableBackgroundBorderless` for Android API level < 21

### DIFF
--- a/src/CloseButton.android.js
+++ b/src/CloseButton.android.js
@@ -3,13 +3,14 @@ import {
   Image,
   StyleSheet,
   TouchableNativeFeedback,
-  View
+  View,
+  Platform
 } from 'react-native';
 
 const CloseButton = (props) => (
   <View style={styles.closeButton}>
     <TouchableNativeFeedback
-      background={TouchableNativeFeedback.SelectableBackgroundBorderless()}
+      background={Platform.Version < 21 ? TouchableNativeFeedback.SelectableBackground() : TouchableNativeFeedback.SelectableBackgroundBorderless()}
       {...props}
     >
       <View>


### PR DESCRIPTION
This PR fixed a crash on Android 4.4.2 (API level 19) when the picker modal popped up. Caused by calling [TouchableNativeFeedback.SelectableBackgroundBorderless][1] which is available on Android API level 21+.

Crash message:
```log
E/unknown:ViewManager(10320): Error while updating prop nativeBackgroundAndroid
E/unknown:ViewManager(10320): java.lang.reflect.InvocationTargetException
E/unknown:ViewManager(10320): 	at java.lang.reflect.Method.invokeNative(Native Method)
E/unknown:ViewManager(10320): 	at java.lang.reflect.Method.invoke(Method.java:515)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp(ViewManagersPropertyCache.java:77)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.ViewManagerPropertyUpdater$FallbackViewManagerSetter.setProperty(ViewManagerPropertyUpdater.java:123)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.ViewManagerPropertyUpdater.updateProps(ViewManagerPropertyUpdater.java:42)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:34)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.NativeViewHierarchyManager.createView(NativeViewHierarchyManager.java:220)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.UIViewOperationQueue$CreateViewOperation.execute(UIViewOperationQueue.java:148)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.dispatchPendingNonBatchedOperations(UIViewOperationQueue.java:890)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded(UIViewOperationQueue.java:863)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.GuardedChoreographerFrameCallback.doFrame(GuardedChoreographerFrameCallback.java:32)
E/unknown:ViewManager(10320): 	at com.facebook.react.uimanager.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:125)
E/unknown:ViewManager(10320): 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:786)
E/unknown:ViewManager(10320): 	at android.view.Choreographer.doCallbacks(Choreographer.java:591)
E/unknown:ViewManager(10320): 	at android.view.Choreographer.doFrame(Choreographer.java:559)
E/unknown:ViewManager(10320): 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:774)
E/unknown:ViewManager(10320): 	at android.os.Handler.handleCallback(Handler.java:808)
E/unknown:ViewManager(10320): 	at android.os.Handler.dispatchMessage(Handler.java:103)
E/unknown:ViewManager(10320): 	at android.os.Looper.loop(Looper.java:193)
E/unknown:ViewManager(10320): 	at android.app.ActivityThread.main(ActivityThread.java:5292)
E/unknown:ViewManager(10320): 	at java.lang.reflect.Method.invokeNative(Native Method)
E/unknown:ViewManager(10320): 	at java.lang.reflect.Method.invoke(Method.java:515)
E/unknown:ViewManager(10320): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:828)
E/unknown:ViewManager(10320): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:644)
E/unknown:ViewManager(10320): 	at dalvik.system.NativeStart.main(Native Method)
E/unknown:ViewManager(10320): Caused by: com.facebook.react.bridge.JSApplicationIllegalArgumentException: Attribute selectableItemBackgroundBorderless couldn't be found in the resource list
E/unknown:ViewManager(10320): 	at com.facebook.react.views.view.ReactDrawableHelper.createDrawableFromJSDescription(ReactDrawableHelper.java:43)
E/unknown:ViewManager(10320): 	at com.facebook.react.views.view.ReactViewManager.setNativeBackground(ReactViewManager.java:105)
```

[1]: http://facebook.github.io/react-native/releases/0.30/docs/touchablenativefeedback.html#selectablebackgroundborderless