### PR TITLE
Remove Peer dependencies and allow to customize flag button

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,5 @@
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^6.0.0",
     "eslint-plugin-react-native": "2.0.0"
-  },
-  "peerDependencies": {
-    "react": "15.3.1",
-    "react-native": "^0.32.0"
   }
 }

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -39,6 +39,7 @@ export default class CountryPicker extends Component {
     translation: React.PropTypes.string,
     onChange: React.PropTypes.func.isRequired,
     closeable: React.PropTypes.bool,
+    children: React.PropTypes.node,
   }
   static defaultProps = {
     translation: 'eng',
@@ -135,7 +136,7 @@ export default class CountryPicker extends Component {
     const country = countries[cca2];
     return (
       <View style={styles.itemCountry}>
-        {this.renderFlag(cca2)}
+        {CountryPicker.renderFlag(cca2)}
         <View style={styles.itemCountryName}>
           <Text style={styles.countryName}>
             {this.getCountryName(country)}
@@ -145,27 +146,27 @@ export default class CountryPicker extends Component {
     );
   }
 
-  renderEmojiFlag(cca2) {
+  static renderEmojiFlag(cca2, emojiStyle) {
     return (
-      <Text style={styles.emojiFlag}>
+      <Text style={[ styles.emojiFlag, emojiStyle ]}>
         <Emoji name={countries[cca2].flag} />
       </Text>
     );
   }
 
-  renderImageFlag(cca2) {
+  static renderImageFlag(cca2, imageStyle) {
     return (
       <Image
-        style={styles.imgStyle}
+        style={[ styles.imgStyle, imageStyle ]}
         source={{ uri: countries[cca2].flag }}
       />
     );
   }
 
-  renderFlag(cca2) {
+  static renderFlag(cca2, itemStyle, emojiStyle, imageStyle) {
     return (
-      <View style={styles.itemCountryFlag}>
-        {isEmojiable ? this.renderEmojiFlag(cca2) : this.renderImageFlag(cca2)}
+      <View style={[ styles.itemCountryFlag, itemStyle ]}>
+        {isEmojiable ? CountryPicker.renderEmojiFlag(cca2, emojiStyle) : CountryPicker.renderImageFlag(cca2, imageStyle)}
       </View>
     );
   }
@@ -175,11 +176,15 @@ export default class CountryPicker extends Component {
       <View>
         <TouchableOpacity
           onPress={() => this.setState({ modalVisible: true })}
-          activeOpacity={0.7}
-        >
-          <View style={styles.touchFlag}>
-            {this.renderFlag(this.props.cca2)}
-          </View>
+          activeOpacity={0.7}>
+          {
+            this.props.children ?
+              this.props.children
+            :
+              (<View style={styles.touchFlag}>
+                {CountryPicker.renderFlag(this.props.cca2)}
+              </View>)
+          }
         </TouchableOpacity>
         <Modal
           visible={this.state.modalVisible}


### PR DESCRIPTION
Remove peer decencies of `react` and `react-native`.

Allow to customize flag button with static methods and children, example:

```
              <CountryPicker
                ref={ (c) => (this._countryPicker = c) }
                onChange={(value)=> this.setState({country: value, cca2: value.cca2})}
                cca2={this.state.cca2}
                translation="fra"
                closeable={ true }>
                <View style={{ flexDirection: 'row' }}>
                  { CountryPicker.renderFlag(this.state.cca2, { height: 26, width: 35 }) }
                  <Text style={ styles.phoneCountry }>
                    { `+${this.state.country.callingCode}` }
                  </Text>
                </View>
              </CountryPicker>
```