### PR TITLE
Various fixes explained in description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-country-picker-modal",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Country picker",
   "main": "src/CountryPicker.js",
   "repository": {

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -149,17 +149,17 @@ export default class CountryPicker extends Component {
   static renderEmojiFlag(cca2, emojiStyle) {
     return (
       <Text style={[ styles.emojiFlag, emojiStyle ]}>
-        <Emoji name={countries[cca2].flag} />
+        { cca2 !== '' ? <Emoji name={countries[cca2].flag} /> : null }
       </Text>
     );
   }
 
   static renderImageFlag(cca2, imageStyle) {
     return (
-      <Image
-        style={[ styles.imgStyle, imageStyle ]}
-        source={{ uri: countries[cca2].flag }}
-      />
+      { cca2 !== '' ? <Image
+          style={[ styles.imgStyle, imageStyle ]}
+          source={{ uri: countries[cca2].flag }}
+        /> : null }
     );
   }
 

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -155,12 +155,10 @@ export default class CountryPicker extends Component {
   }
 
   static renderImageFlag(cca2, imageStyle) {
-    return (
-      { cca2 !== '' ? <Image
-          style={[ styles.imgStyle, imageStyle ]}
-          source={{ uri: countries[cca2].flag }}
-        /> : null }
-    );
+    return cca2 !== '' ? <Image
+        style={[ styles.imgStyle, imageStyle ]}
+        source={{ uri: countries[cca2].flag }}
+      /> : null;
   }
 
   static renderFlag(cca2, itemStyle, emojiStyle, imageStyle) {

--- a/src/CountryPicker.style.js
+++ b/src/CountryPicker.style.js
@@ -31,6 +31,7 @@ export default StyleSheet.create({
     height: 30,
     borderWidth: 1 / PixelRatio.get(),
     borderColor: 'transparent',
+    backgroundColor: 'transparent',
   },
   itemCountry: {
     flexDirection: 'row',


### PR DESCRIPTION
- Fixes black background on the flag with RN 0.40 at iOS devices
- Adds support to render the component without an initial flag. Useful when you use it as a picker and the user has not selected a country yet.
- Increases package version
