### PR TITLE
Fix error with react-native 0.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/xcarpentier/react-native-country-picker-modal#readme",
   "dependencies": {
     "babel-preset-react-native-stage-0": "1.0.1",
-    "fuse.js": "^2.6.2",
+    "fuse.js": "2.6.2",
     "lodash": "4.12.0",
     "react-native-emoji": "git://github.com/niftylettuce/react-native-emoji.git",
     "world-countries": "1.8.0"


### PR DESCRIPTION
Fix issue that component would show the error message: Unknown plugin "babel-plugin-add-module-exports" at the beginning