### PR TITLE
update cca2List and dataSource state when receiving new props

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -150,6 +150,15 @@ export default class CountryPicker extends Component {
     );
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.countryList !== this.props.countryList) {
+      this.setState({
+        cca2List: nextProps.countryList,
+        dataSource: ds.cloneWithRows(nextProps.countryList),
+      });
+    }
+  }
+
   onSelectCountry(cca2) {
     this.setState({
       modalVisible: false,


### PR DESCRIPTION
I need to display different country list as I've got different rate plans that support calling to different country. In the past when the user select a plan the country list did not change. This PR fixes this by listening to React lifecycle event `componentWillReceiveProps()` and update the `cca2List` and `dataSource` if needed.