### PR TITLE
Sort country list according to translation property

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -113,6 +113,15 @@ export default class CountryPicker extends Component {
       }
     });
 
+    // Sort country list
+    countryList = countryList
+      .map(c => [c, this.getCountryName(countries[c])])
+      .sort((a, b) => {
+        if (a[1] < b[1]) return -1;
+        if (a[1] > b[1]) return 1;
+        return 0;
+      }).map(c => c[0]);
+
     this.state = {
       modalVisible: false,
       cca2List: countryList,
@@ -204,7 +213,7 @@ export default class CountryPicker extends Component {
 
   scrollTo(letter) {
     // find position of first country that starts with letter
-    const index = this.state.cca2List.map((country) => countries[country].name.common[0])
+    const index = this.state.cca2List.map((country) => this.getCountryName(countries[country])[0])
       .indexOf(letter);
     if (index === -1) {
       return;


### PR DESCRIPTION
Currently when passing a translation property such as DE the country list gets translated but the sorting remains from the original EN translation (also the letters list clicking), this PR fixes this