### PR TITLE
fix Deprecation Warnings RN >= 0.43 react >= 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "babel-preset-react-native-stage-0": "1.0.1",
     "fuse.js": "2.6.2",
     "lodash": "4.12.0",
-    "react-native-emoji": "git://github.com/niftylettuce/react-native-emoji.git",
+    "node-emoji": "^1.6.1",
+    "prop-types": "^15.5.10",
     "world-countries": "1.8.0"
   },
   "devDependencies": {

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -6,6 +6,7 @@
 
 // eslint-disable-next-line
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 // eslint-disable-next-line
 import {
   StyleSheet,
@@ -26,6 +27,7 @@ import { getHeightPercent } from './ratio';
 import CloseButton from './CloseButton';
 import countryPickerStyles from './CountryPicker.style';
 import KeyboardAvoidingView from './KeyboardAvoidingView';
+import EmojiView from './Emoji'
 
 let countries = null;
 let Emoji = null;
@@ -39,7 +41,7 @@ const isEmojiable = Platform.OS === 'ios';
 
 if (isEmojiable) {
   countries = require('../data/countries-emoji');
-  Emoji = require('react-native-emoji').default;
+  Emoji = EmojiView;
 } else {
   countries = require('../data/countries');
 
@@ -52,18 +54,18 @@ const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 });
 
 export default class CountryPicker extends Component {
   static propTypes = {
-    cca2: React.PropTypes.string.isRequired,
-    translation: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    onClose: React.PropTypes.func,
-    closeable: React.PropTypes.bool,
-    filterable: React.PropTypes.bool,
-    children: React.PropTypes.node,
-    countryList: React.PropTypes.array,
-    excludeCountries: React.PropTypes.array,
-    styles: React.PropTypes.object,
-    filterPlaceholder: React.PropTypes.string,
-    autoFocusFilter: React.PropTypes.bool,
+    cca2: PropTypes.string.isRequired,
+    translation: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
+    closeable: PropTypes.bool,
+    filterable: PropTypes.bool,
+    children: PropTypes.node,
+    countryList: PropTypes.array,
+    excludeCountries: PropTypes.array,
+    styles: PropTypes.object,
+    filterPlaceholder: PropTypes.string,
+    autoFocusFilter: PropTypes.bool,
   }
 
   static defaultProps = {

--- a/src/Emoji.js
+++ b/src/Emoji.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text } from 'react-native';
+import nodeEmoji from 'node-emoji';
+import PropTypes from 'prop-types';
+
+class Emoji extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+  }
+
+  render() {
+    const emoji = nodeEmoji.get(this.props.name);
+    return (<Text>{ emoji }</Text>);
+  }
+}
+
+export default Emoji;

--- a/src/KeyboardAvoidingView.android.js
+++ b/src/KeyboardAvoidingView.android.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   View,
@@ -16,9 +16,9 @@ const KeyboardAvoidingView = props => (
 );
 
 KeyboardAvoidingView.propTypes = {
-  offset: React.PropTypes.number,
-  children: React.PropTypes.node,
-  styles: React.PropTypes.array,
+  offset: PropTypes.number,
+  children: PropTypes.node,
+  styles: PropTypes.array,
 };
 
 export default KeyboardAvoidingView;

--- a/src/KeyboardAvoidingView.ios.js
+++ b/src/KeyboardAvoidingView.ios.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   KeyboardAvoidingView as NativeKeyboardAvoidingView,
@@ -24,9 +24,9 @@ const KeyboardAvoidingView = props => (
 );
 
 KeyboardAvoidingView.propTypes = {
-  offset: React.PropTypes.number,
-  children: React.PropTypes.node,
-  styles: React.PropTypes.array,
+  offset: PropTypes.number,
+  children: PropTypes.node,
+  styles: PropTypes.array,
 };
 
 export default KeyboardAvoidingView;


### PR DESCRIPTION
Fix Deprecation Warnings RN >= 0.43 about PropTypes access. Removed dependency on react-native-emoji, instead depend directly on node-emoji. react-native-emoji seems to be unsupported for 2 years.