### PR TITLE
Disable/Enable the onPress event of Country Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ AppRegistry.registerComponent('example', () => Example);
 | filterable | bool | false | If true, the CountryPicker will have search bar |
 | filterPlaceholder | string | 'Filter' | The search bar placeholder |
 | autoFocusFilter | bool | true | Whether or not the search bar should be autofocused |
-| styles | object | {} | Override any style specified in the component (see source code)
+| styles | object | {} | Override any style specified in the component (see source code)|
+| disabled | bool | false | Whether or not the Country Picker onPress is disabled
 
 ## Dependencies
 - world-countries : https://www.npmjs.com/package/world-countries

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -295,6 +295,7 @@ export default class CountryPicker extends Component {
     return (
       <View>
         <TouchableOpacity
+          disabled={this.props.disabled}    //to provide a functionality to disable/enable the onPress of Country Picker.
           onPress={() => this.setState({ modalVisible: true })}
           activeOpacity={0.7}
         >


### PR DESCRIPTION
Sometimes it is requirement to have a component like Uber's Login screen in which the country picker is disabled at first.