### PR TITLE
Took out react-native-emoji dependency. It is tiny, and not up-to-date

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-preset-react-native-stage-0": "1.0.1",
     "fuse.js": "2.6.2",
     "lodash": "4.12.0",
-    "react-native-emoji": "git://github.com/niftylettuce/react-native-emoji.git",
+    "node-emoji": "1.8.1",
     "world-countries": "1.8.0"
   },
   "devDependencies": {

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -50,7 +50,7 @@ const isEmojiable = Platform.OS === 'ios';
 
 if (isEmojiable) {
   countries = require('../data/countries-emoji');
-  Emoji = require('react-native-emoji').default;
+  Emoji = require('./emoji').default;
 } else {
   countries = require('../data/countries');
 

--- a/src/emoji.js
+++ b/src/emoji.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Text } from 'react-native';
+import nodeEmoji from 'node-emoji';
+
+PropTypes = require('prop-types');
+
+if (!PropTypes) {
+  PropTypes = React.PropTypes;
+}
+
+class Emoji extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+  }
+
+  render() {
+    const emoji = nodeEmoji.get(this.props.name);
+    return (<Text>{ emoji }</Text>);
+  }
+}
+
+export default Emoji;


### PR DESCRIPTION
This takes out the library, put it directly in this repo, and fixed the issues it had with React 16 prop-types.