### PR TITLE
Additional optional prop 'flagType' to enforce a certain flag type usage across platforms

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -28,21 +28,33 @@ let countries = null
 let Emoji = null
 let styles = {}
 
-const isEmojiable = Platform.OS === 'ios'
+let isEmojiable = Platform.OS === 'ios'
 
-if (isEmojiable) {
-  countries = require('../data/countries-emoji')
-  Emoji = require('./emoji').default
-} else {
-  countries = require('../data/countries')
-
-  Emoji = <View />
+const FLAG_TYPES = {
+  flat: 'flat',
+  emoji: 'emoji'
 }
+
+const setCountries = (flagType) => {
+  if (typeof flagType !== 'undefined') {
+    isEmojiable = flagType === FLAG_TYPES.emoji;
+  }
+
+  if (isEmojiable) {
+    countries = require('../data/countries-emoji')
+    Emoji = require('./emoji').default
+  } else {
+    countries = require('../data/countries')
+    Emoji = <View />
+  }
+};
+
+const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
+
+setCountries();
 
 export const getAllCountries = () =>
   cca2List.map(cca2 => ({ ...countries[cca2], cca2 }))
-
-const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
 
 export default class CountryPicker extends Component {
   static propTypes = {
@@ -63,7 +75,8 @@ export default class CountryPicker extends Component {
     filterPlaceholderTextColor: PropTypes.string,
     closeButtonImage: PropTypes.element,
     transparent: PropTypes.bool,
-    animationType: PropTypes.oneOf(['slide', 'fade', 'none'])
+    animationType: PropTypes.oneOf(['slide', 'fade', 'none']),
+    flagType: PropTypes.oneOf(Object.values(FLAG_TYPES))
   }
 
   static defaultProps = {
@@ -109,6 +122,7 @@ export default class CountryPicker extends Component {
     super(props)
     this.openModal = this.openModal.bind(this)
 
+    setCountries(props.flagType)
     let countryList = [...props.countryList]
     const excludeCountries = [...props.excludeCountries]
 


### PR DESCRIPTION
Introducing additional optional prop 'flagType' to enforce a certain flag type usage across platforms. Now the package forces you to use emoji flags on iOS and flat on Android.
This PR adds more versatility without changing the default behaviour.

flagType: 'flat' | 'emoji'