### PR TITLE
added filterOptions prop for override Fuse.js search options

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -81,7 +81,8 @@ export default class CountryPicker extends Component {
     flagType: PropTypes.oneOf(Object.values(FLAG_TYPES)),
     hideAlphabetFilter: PropTypes.bool,
     renderFilter: PropTypes.func,
-    showCallingCode: PropTypes.bool
+    showCallingCode: PropTypes.bool,
+    filterOptions: PropTypes.object
   }
 
   static defaultProps = {
@@ -169,6 +170,16 @@ export default class CountryPicker extends Component {
       styles = countryPickerStyles
     }
 
+    const options = Object.assign({
+      shouldSort: true,
+      threshold: 0.6,
+      location: 0,
+      distance: 100,
+      maxPatternLength: 32,
+      minMatchCharLength: 1,
+      keys: ['name'],
+      id: 'id'
+    },  this.props.filterOptions);
     this.fuse = new Fuse(
       countryList.reduce(
         (acc, item) => [
@@ -177,16 +188,7 @@ export default class CountryPicker extends Component {
         ],
         []
       ),
-      {
-        shouldSort: true,
-        threshold: 0.6,
-        location: 0,
-        distance: 100,
-        maxPatternLength: 32,
-        minMatchCharLength: 1,
-        keys: ['name'],
-        id: 'id'
-      }
+      options
     )
   }
 


### PR DESCRIPTION
Sometime Fuze library give unexpected result. With default options when I type 'fr' I can see in result list 'Ukraine' country. Reason when it happens - 'threshold: 0.6' parameter from fuse.js library.
My pull-request gives ability to override all options from client code.