### PR TITLE
add TypeScript typings for countrypicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "world-countries": "1.8.0"
   },
   "devDependencies": {
+    "@types/react": "^16.4.6",
+    "@types/react-native": "^0.55.26",
     "babel-cli": "6.14.0",
     "babel-eslint": "6.1.2",
     "babel-jest": "23.0.1",
@@ -59,7 +61,8 @@
     "react": "16.0.0",
     "react-native": "0.50.3",
     "react-test-renderer": "16.0.0",
-    "regenerator-runtime": "0.11.1"
+    "regenerator-runtime": "0.11.1",
+    "typescript": "^2.9.2"
   },
   "jest": {
     "preset": "react-native",

--- a/src/CountryPicker.d.ts
+++ b/src/CountryPicker.d.ts
@@ -2,8 +2,8 @@ import { StyleProp, ViewStyle, ImageProps } from 'react-native';
 import * as React from 'react';
 import countries from '../data/countries.json';
 
-export type Country = (typeof countries)[CountryCode];
-export type CountryCode = keyof typeof countries;
+export type Country = (typeof countries)[CCA2Code];
+export type CCA2Code = keyof typeof countries;
 export type CallingCode = string;
 export type CurrencyCode = string;
 export type LanguageCode = keyof Country['name'];
@@ -20,9 +20,9 @@ export enum AnimationType {
 
 export interface CountryPickerProps {
   /**
-   * code ISO 3166-1 alpha-2 (ie. FR, US, etc.)
+   * Country code, as specified in ISO 3166-1 alpha-2 (ie. FR, US, etc.)
    */
-  cca2: CountryCode;
+  cca2: CCA2Code;
   /**
    * The handler when a country is selected
    */
@@ -42,7 +42,7 @@ export interface CountryPickerProps {
   /**
    * List of custom CCA2 countries to render in the list. Use getAllCountries to filter what you need if you want to pass in a custom list
    */
-  countryList?: CountryCode[];
+  countryList?: CCA2Code[];
   /**
    * The language display for the name of the country
    */
@@ -58,7 +58,7 @@ export interface CountryPickerProps {
   /**
    * List of custom CCA2 countries you don't want to render
    */
-  excludeCountries?: CountryCode[];
+  excludeCountries?: CCA2Code[];
   /**
    * The search bar placeholder
    */

--- a/src/CountryPicker.d.ts
+++ b/src/CountryPicker.d.ts
@@ -2,11 +2,28 @@ import { StyleProp, ViewStyle, ImageProps } from 'react-native';
 import * as React from 'react';
 import countries from '../data/countries.json';
 
+/**
+ * Country metadata stored in this library to display and query `<CountryPicker
+ * />`
+ */
 export type Country = (typeof countries)[CCA2Code];
+/**
+ * Country code, as specified in ISO 3166-1 alpha-2 (ie. `FR`, `US`, etc.)
+ */
 export type CCA2Code = keyof typeof countries;
+/**
+ * Calling code for a given country. For example: `United States (+1)`
+ */
 export type CallingCode = string;
+/**
+ * Currency code for a country, as specified in ISO 4217. For example, US
+ * Dollars are `USD`
+ */
 export type CurrencyCode = string;
-export type LanguageCode = keyof Country['name'];
+/**
+ * Language codes for available translations in this library
+ */
+export type TranslationLanguageCode = keyof Country['name'];
 
 export enum FlagType {
   FLAT = 'flat',
@@ -20,7 +37,7 @@ export enum AnimationType {
 
 export interface CountryPickerProps {
   /**
-   * Country code, as specified in ISO 3166-1 alpha-2 (ie. FR, US, etc.)
+   * Country code, as specified in ISO 3166-1 alpha-2 (ie. `FR`, `US`, etc.)
    */
   cca2: CCA2Code;
   /**
@@ -46,7 +63,7 @@ export interface CountryPickerProps {
   /**
    * The language display for the name of the country
    */
-  translation?: LanguageCode;
+  translation?: TranslationLanguageCode;
   /**
    * If true, the CountryPicker will have a close button
    */
@@ -106,7 +123,9 @@ export interface CountryPickerProps {
     }
   ) => React.ReactNode;
 }
+
 export default class CountryPicker extends React.Component<CountryPickerProps> {
   openModal: () => void;
 }
+
 export function getAllCountries(): Country[];

--- a/src/CountryPicker.d.ts
+++ b/src/CountryPicker.d.ts
@@ -1,0 +1,130 @@
+import { StyleProp, ViewStyle, ImageProps } from 'react-native';
+import * as React from 'react';
+
+export type CountryCode = string;
+export type CallingCode = string;
+export type CurrencyCode = string;
+export type LanguageCode =
+  | 'deu'
+  | 'fra'
+  | 'hrv'
+  | 'ita'
+  | 'jpn'
+  | 'nld'
+  | 'por'
+  | 'rus'
+  | 'spa'
+  | 'svk'
+  | 'fin'
+  | 'zho'
+  | 'isr';
+
+export interface Country {
+  cca2: CountryCode;
+  callingCode: CallingCode;
+  currency: CurrencyCode;
+  flag: string; // data uri
+  name: { [key in LanguageCode]: string };
+}
+export enum FlagType {
+  FLAT = 'flat',
+  EMOJI = 'emoji'
+}
+export enum AnimationType {
+  SLIDE = 'slide',
+  FADE = 'fade',
+  NONE = 'none'
+}
+
+export interface CountryPickerProps {
+  /**
+   * code ISO 3166-1 alpha-2 (ie. FR, US, etc.)
+   */
+  cca2: CountryCode;
+  /**
+   * The handler when a country is selected
+   */
+  onChange: (value: Country) => void;
+  /**
+   * Override any style specified in the component (see source code)
+   */
+  styles?: StyleProp<ViewStyle>;
+  /**
+   * If set to true, Country Picker List will show calling code after country name. For example: `United States (+1)`
+   */
+  showCallingCode?: boolean;
+  /**
+   * The handler when the close button is clicked
+   */
+  onClose?: () => void;
+  /**
+   * List of custom CCA2 countries to render in the list. Use getAllCountries to filter what you need if you want to pass in a custom list
+   */
+  countryList?: CountryCode[];
+  /**
+   * The language display for the name of the country
+   */
+  translation?: LanguageCode;
+  /**
+   * If true, the CountryPicker will have a close button
+   */
+  closeable?: boolean;
+  /**
+   * If true, the CountryPicker will have search bar
+   */
+  filterable?: boolean;
+  /**
+   * List of custom CCA2 countries you don't want to render
+   */
+  excludeCountries?: CountryCode[];
+  /**
+   * The search bar placeholder
+   */
+  filterPlaceholder?: string;
+  /**
+   * Whether or not the search bar should be autofocused
+   */
+  autoFocusFilter?: boolean;
+  /**
+   * Whether or not the Country Picker onPress is disabled
+   */
+  disabled?: boolean;
+  /**
+   * The search bar placeholder text color
+   */
+  filterPlaceholderTextColor?: string;
+  /**
+   * Custom close button Image
+   */
+  closeButtonImage?: ImageProps['source'];
+  /**
+   * If true, the CountryPicker will render the modal over a transparent background
+   */
+  transparent?: boolean;
+  /**
+   * The handler that controls how the modal animates
+   */
+  animationType?: AnimationType;
+  /**
+   * If set, overwrites the default OS based flag type.
+   */
+  flagType?: FlagType;
+  /**
+   * If set to true, prevents the alphabet filter rendering
+   */
+  hideAlphabetFilter?: boolean;
+  /**
+   * If 'filterable={true}' and renderFilter function is provided, render custom filter component.*
+   */
+  renderFilter?: (
+    args: {
+      value: string;
+      onChange: CountryPickerProps['onChange'];
+      onClose: CountryPickerProps['onClose'];
+    }
+  ) => React.ReactNode;
+}
+export default class CountryPicker extends React.Component<CountryPickerProps> {
+  openModal: () => void;
+}
+export function getAllCountries(): Country[];

--- a/src/CountryPicker.d.ts
+++ b/src/CountryPicker.d.ts
@@ -1,31 +1,13 @@
 import { StyleProp, ViewStyle, ImageProps } from 'react-native';
 import * as React from 'react';
+import countries from '../data/countries.json';
 
-export type CountryCode = string;
+export type Country = (typeof countries)[CountryCode];
+export type CountryCode = keyof typeof countries;
 export type CallingCode = string;
 export type CurrencyCode = string;
-export type LanguageCode =
-  | 'deu'
-  | 'fra'
-  | 'hrv'
-  | 'ita'
-  | 'jpn'
-  | 'nld'
-  | 'por'
-  | 'rus'
-  | 'spa'
-  | 'svk'
-  | 'fin'
-  | 'zho'
-  | 'isr';
+export type LanguageCode = keyof Country['name'];
 
-export interface Country {
-  cca2: CountryCode;
-  callingCode: CallingCode;
-  currency: CurrencyCode;
-  flag: string; // data uri
-  name: { [key in LanguageCode]: string };
-}
 export enum FlagType {
   FLAT = 'flat',
   EMOJI = 'emoji'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    // "target":
-    //   "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    // "module":
-    //   "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "noEmit": true /* Do not emit outputs. */,
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
@@ -35,28 +16,8 @@
     "noUnusedLocals": true /* Report errors on unused locals. */,
     "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    // "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "resolveJsonModule": true /* Resolve JSON modules to get types from JSON source data*/
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "target":
+    //   "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    // "module":
+    //   "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "resolveJsonModule": true /* Resolve JSON modules to get types from JSON source data*/
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,18 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/react-native@^0.55.26":
+  version "0.55.26"
+  resolved "https://registry.npmjs.org/@types/react-native/-/react-native-0.55.26.tgz#a7150ca15e0de7e435cc66a1ca44f6b506c99e40"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.4.6":
+  version "16.4.6"
+  resolved "https://registry.npmjs.org/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
+  dependencies:
+    csstype "^2.2.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1509,6 +1521,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.5.5"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
 
 csurf@~1.8.3:
   version "1.8.3"
@@ -5575,6 +5591,10 @@ type-is@~1.6.6:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
Closes #127 .

I think this is how you add typings, seems to work when I import it via a `file://` dependency locally. But yeah I think all of these are accurate based on reading the docs and code as well as deriving much of the types from the source data.