### PR TITLE
Option to add country name next to flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ const darkTheme = StyleSheet.create({
 | closeButtonImage  | React.element| default close button Image                                                                               | Custom close button Image
 | flagType  | string | 'emoji' on iOS, 'flat' on Android | If set, overwrites the default OS based flag type.
 | hideAlphabetFilter  | bool | false | If set to true, prevents the alphabet filter rendering
+| showCountryNameWithFlag   | bool  | false | If set, then country name will appear next to flag in the view
 | showCallingCode | bool | false | If set to true, Country Picker List will show calling code after country name `United States (+1)`
 | renderFilter  | Function | undefined | If 'filterable={true}' and renderFilter function is provided, render custom filter component.\*
 

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -137,7 +137,7 @@ export default class CountryPicker extends Component {
             : CountryPicker.renderImageFlag(cca2, imageStyle)}
 
         </View>
-        <Text style={{marginLeft:15,fontSize:20}}>{countryName}</Text>
+        <Text style={{marginLeft:15,fontSize:16}}>{countryName}</Text>
       </View>
     )
   }

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -84,7 +84,8 @@ export default class CountryPicker extends Component {
     hideCountryFlag: PropTypes.bool,
     renderFilter: PropTypes.func,
     showCallingCode: PropTypes.bool,
-    filterOptions: PropTypes.object
+    filterOptions: PropTypes.object,
+    showCountryNameWithFlag: PropTypes.bool
   }
 
   static defaultProps = {
@@ -123,6 +124,20 @@ export default class CountryPicker extends Component {
         {isEmojiable
           ? CountryPicker.renderEmojiFlag(cca2, emojiStyle)
           : CountryPicker.renderImageFlag(cca2, imageStyle)}
+      </View>
+    )
+  }
+
+  static renderFlagWithName(cca2,countryName, itemStyle, emojiStyle, imageStyle) {
+    return (
+      <View style={{flexDirection:'row', flexWrap:'wrap',alignItems: "center",}}>
+        <View style={[countryPickerStyles.itemCountryFlag, itemStyle]}>
+          {isEmojiable
+            ? CountryPicker.renderEmojiFlag(cca2, emojiStyle)
+            : CountryPicker.renderImageFlag(cca2, imageStyle)}
+
+        </View>
+        <Text style={{marginLeft:15,fontSize:20}}>{countryName}</Text>
       </View>
     )
   }
@@ -380,7 +395,12 @@ export default class CountryPicker extends Component {
             <View
               style={[styles.touchFlag, { marginTop: isEmojiable ? 0 : 5 }]}
             >
-              {CountryPicker.renderFlag(this.props.cca2,
+              {this.props.showCountryNameWithFlag && CountryPicker.renderFlagWithName(this.props.cca2,this.getCountryName(countries[this.props.cca2]),
+                styles.itemCountryFlag,
+                styles.emojiFlag,
+                styles.imgStyle)}
+
+              {!this.props.showCountryNameWithFlag && CountryPicker.renderFlag(this.props.cca2,
                 styles.itemCountryFlag,
                 styles.emojiFlag,
                 styles.imgStyle)}


### PR DESCRIPTION
An option to add the country name next to the flag in the view (not in the list view). This will provide a greater area for tapping as compared to the flag and some times it's easy to recognize the country by name instead of just flag.