### PR TITLE
Fix TypeError: undefined is not an object (evaluating 'country.name')

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -244,6 +244,9 @@ export default class CountryPicker extends Component {
   }
 
   getCountryName(country, optionalTranslation) {
+    if (!country) {
+      return ''
+    }
     const translation = optionalTranslation || this.props.translation || 'eng'
     return country.name[translation] || country.name.common
   }


### PR DESCRIPTION
I get this error when I create a CountryPicker with showCountryNameWithFlag but without init value.