### PR TITLE
Scroll to locations outside the render

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -434,6 +434,7 @@ componentDidUpdate (prevProps) {
               <View style={styles.contentContainer}>
                 <FlatList
                   testID="list-countries"
+                  keyboardShouldPersistTaps="handled"
                   data={this.state.flatListMap}
                   ref={flatList => (this._flatList = flatList)}
                   initialNumToRender={30}

--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -439,9 +439,9 @@ componentDidUpdate (prevProps) {
                   initialNumToRender={30}
                   renderItem={country => this.renderCountry(country.item.key)}
                   keyExtractor={(item) => item.key}
-                  onScrollToIndexFailed={()=> {
-                    console.log('onScrollToIndexFailed')
-                  }}
+                  getItemLayout={(data, index) => (
+                    { length: this.itemHeight, offset: this.itemHeight * index, index }
+                  )}
                 />
                 {!this.props.hideAlphabetFilter && (
                   <ScrollView


### PR DESCRIPTION
If user press alphabetic which related county names outside of FlatList renderer, the scrollToIndex is not working. The issue is FlatList cannot scroll to locations outside the render window without specifying the getItemLayout prop.