### PR TITLE
[android] allow country picker modal reuse custom styles

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -346,7 +346,11 @@ componentDidUpdate (prevProps) {
     const country = countries[cca2]
     return (
       <View style={styles.itemCountry}>
-        {!this.props.hideCountryFlag && CountryPicker.renderFlag(cca2)}
+        {!this.props.hideCountryFlag &&
+          CountryPicker.renderFlag(cca2,
+                styles.itemCountryFlag,
+                styles.emojiFlag,
+                styles.imgStyle)}
         <View style={styles.itemCountryName}>
           <Text style={styles.countryName} allowFontScaling>
             {this.getCountryName(country)}


### PR DESCRIPTION
On Android, country picker could not show flags. This PR allows applying custom styles to the modal


![image](https://user-images.githubusercontent.com/8109285/63226427-90b54500-c203-11e9-9a8e-77667fe63f7c.png)
