### PR TITLE
Fix for flag rendering on Android

### DIFF
--- a/src/CountryPicker.js
+++ b/src/CountryPicker.js
@@ -109,6 +109,7 @@ export default class CountryPicker extends Component {
   static renderImageFlag(cca2, imageStyle) {
     return cca2 !== '' ? (
       <Image
+        resizeMode={'contain'}
         style={[countryPickerStyles.imgStyle, imageStyle]}
         source={{ uri: countries[cca2].flag }}
       />
@@ -442,7 +443,7 @@ componentDidUpdate (prevProps) {
                   data={this.state.flatListMap}
                   ref={flatList => (this._flatList = flatList)}
                   initialNumToRender={30}
-onScrollToIndexFailed={()=>{}}
+                  onScrollToIndexFailed={()=>{}}
                   renderItem={country => this.renderCountry(country.item.key)}
                   keyExtractor={(item) => item.key}
                   getItemLayout={(data, index) => (

--- a/src/CountryPicker.style.js
+++ b/src/CountryPicker.style.js
@@ -32,7 +32,7 @@ export default StyleSheet.create({
   imgStyle: {
     resizeMode: 'contain',
     width: 25,
-    // height: 19,
+    height: 19,
     borderWidth: 1 / PixelRatio.get(),
     borderColor: '#eee',
     opacity: 0.8


### PR DESCRIPTION
Symptom: Android not rendering flags

Investigation: Images didn't render on iPhone either when turning off emoji mode

Cause: In RN 0.60+ an <Image> needs width and height set when loading from data: url scheme.

From RN Documentation: _"Note that for network and data images, you will need to manually specify the dimensions of your image!"_

Fix: Added "width" back in, it was commented out, added "contain" to the Image element just in case

I assume if some flags in there aren't 19 high it will look odd. But I tried other height and that messes up the design so left it at 19.

