### PR TITLE
Make the close button optional in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ export default function App() {
 - `withCurrencyButton?`: boolean
 - `withCallingCodeButton?`: boolean
 - `withFlagButton?`: boolean
+- `withCloseButton?`: boolean
 - `withFilter?`: boolean
 - `withFlag?`: boolean
 - `withModal?`: boolean

--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -21,8 +21,8 @@ const renderFlagButton = (
   props.renderFlagButton ? (
     props.renderFlagButton(props)
   ) : (
-    <FlagButton {...props} />
-  )
+      <FlagButton {...props} />
+    )
 
 const renderFilter = (
   props: CountryFilter['props'] & CountryPickerProps['renderCountryFilter']
@@ -30,8 +30,8 @@ const renderFilter = (
   props.renderCountryFilter ? (
     props.renderCountryFilter(props)
   ) : (
-    <CountryFilter {...props} />
-  )
+      <CountryFilter {...props} />
+    )
 
 interface CountryPickerProps {
   countryCode: CountryCode
@@ -46,6 +46,7 @@ interface CountryPickerProps {
   withCurrencyButton?: boolean
   withCallingCodeButton?: boolean
   withFlagButton?: boolean
+  withCloseButton?: boolean
   withFilter?: boolean
   withAlphaFilter?: boolean
   withCallingCode?: boolean
@@ -75,6 +76,7 @@ export const CountryPicker = (props: CountryPickerProps) => {
     onSelect,
     withEmoji,
     withFilter,
+    withCloseButton,
     withCountryNameButton,
     withCallingCodeButton,
     withCurrencyButton,
@@ -148,7 +150,7 @@ export const CountryPicker = (props: CountryPickerProps) => {
         onRequestClose={onClose}
       >
         <HeaderModal
-          {...{ withFilter, onClose }}
+          {...{ withFilter, withCloseButton, onClose }}
           renderFilter={(props: CountryFilter['props']) =>
             renderFilter({
               ...props,

--- a/src/HeaderModal.tsx
+++ b/src/HeaderModal.tsx
@@ -18,6 +18,7 @@ const styles = StyleSheet.create({
 
 interface HeaderModalProps {
   withFilter?: boolean
+  withCloseButton?: boolean
   closeButtonImage?: ImageSourcePropType
   closeButtonStyle?: StyleProp<ViewStyle>
   closeButtonImageStyle?: StyleProp<ImageStyle>
@@ -27,6 +28,7 @@ interface HeaderModalProps {
 export const HeaderModal = (props: HeaderModalProps) => {
   const {
     withFilter,
+    withCloseButton,
     closeButtonImage,
     closeButtonStyle,
     closeButtonImageStyle,
@@ -35,13 +37,17 @@ export const HeaderModal = (props: HeaderModalProps) => {
   } = props
   return (
     <View style={styles.container}>
-      <CloseButton
+      {withCloseButton && <CloseButton
         image={closeButtonImage}
         style={closeButtonStyle}
         imageStyle={closeButtonImageStyle}
         onPress={onClose}
-      />
+      />}
       {withFilter && renderFilter(props)}
     </View>
   )
+}
+
+HeaderModal.defaultProps = {
+  withCloseButton: true
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ interface Props {
   withCountryNameButton?: boolean
   withCurrencyButton?: boolean
   withCallingCodeButton?: boolean
+  withCloseButton?: boolean
   withFilter?: boolean
   withFlag?: boolean
   withModal?: boolean
@@ -52,7 +53,7 @@ export default function main({ theme, translation, ...props }: Props) {
 }
 
 main.defaultProps = {
-  onSelect: () => {},
+  onSelect: () => { },
   withEmoji: true
 }
 


### PR DESCRIPTION
In many use-cases (or at least in mine), I wanted to render a filter bar which would completely take up the entire `HeaderModal`. This PR makes the close button optional by adding a withCloseButton optional prop in the header which is set to true by default.