### PR TITLE
fix main component defaultProps types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ interface Props {
   onClose?(): void
 }
 
-export default function main({ theme, translation, ...props }: Props) {
+const Main = ({ theme, translation, ...props }: Props) => {
   return (
     <ThemeProvider theme={{ ...DEFAULT_THEME, ...theme }}>
       <CountryProvider value={{ ...DEFAULT_COUNTRY_CONTEXT, translation }}>
@@ -53,11 +53,12 @@ export default function main({ theme, translation, ...props }: Props) {
   )
 }
 
-main.defaultProps = {
+Main.defaultProps = {
   onSelect: () => {},
   withEmoji: true,
 }
 
+export default Main
 export {
   getCountriesAsync as getAllCountries,
   getCountryCallingCodeAsync as getCallingCode,


### PR DESCRIPTION
I was getting the following error when using the library in a TypeScript project:

```
../../../../Repositories/react-native-country-picker-modal/lib/index.d.ts:37:26 - error TS1005: ';' expected.

37 export default namespace main {
                            ~~~~

../../../../Repositories/react-native-country-picker-modal/lib/index.d.ts:37:31 - error TS1005: ';' expected.

37 export default namespace main {
                                 ~
```

Defining the default exported component as a const fixed the issue. This PR changes main type definition in `lib/index.d.ts` from
```ts
export default function main({ theme, translation, ...props }: Props): JSX.Element;
export default namespace main {
    var defaultProps: {
        onSelect: () => void;
        withEmoji: boolean;
    };
}
```
to 
```ts
declare const Main: {
    ({ theme, translation, ...props }: Props): JSX.Element;
    defaultProps: {
        onSelect: () => void;
        withEmoji: boolean;
    };
};
export default Main;
```