### PR TITLE
Remove "isr" from the TranslationLanguageCodeList

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -320,8 +320,7 @@ export const TranslationLanguageCodeList = [
   'spa',
   'svk',
   'fin',
-  'zho',
-  'isr'
+  'zho'
 ] as const
 export type TranslationLanguageCode = typeof TranslationLanguageCodeList[number]
 


### PR DESCRIPTION
The countries list doesn't support Hebrew (or whatever `isr` means) translation, so I think it's better to remove it from the `TranslationLanguageCodeList` so it won't be confusing.