### PR TITLE
Tuning fuzzy search

### DIFF
--- a/src/CountryService.ts
+++ b/src/CountryService.ts
@@ -157,12 +157,12 @@ export const getCountriesAsync = async (
 
 const DEFAULT_FUSE_OPTION = {
   shouldSort: true,
-  threshold: 0.6,
+  threshold: 0.3,
   location: 0,
   distance: 100,
   maxPatternLength: 32,
   minMatchCharLength: 1,
-  keys: ['name', 'callingCode'],
+  keys: ['name', 'cca2', 'callingCode'],
 }
 let fuse: Fuse<Country>
 export const search = (


### PR DESCRIPTION
Currently the filter is too fuzzy -- there are usually many unrelated results even if the user types an accurate country name. I found threshold 0.3 to be a fairly good choice.

Also added "cca2" into the search keys; otherwise, it would be a little confusing if searching "US" or "GB" returns no results.
