### PR TITLE
added onDismiss method for iOS13 swipe-to-close behavior

### DIFF
--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -177,6 +177,7 @@ export const CountryPicker = (props: CountryPickerProps) => {
       <CountryModal
         {...{ visible, withModal, disableNativeModal, ...modalProps }}
         onRequestClose={onClose}
+        onDismiss={onClose}
       >
         <HeaderModal
           {...{


### PR DESCRIPTION
On iOS13, there's a behavior to close the RN Modal with a swipe down gesture. In this case, the onDismiss method is called. Without onDismiss, the country picker will not open for the second time because its state will remain open.