### PR TITLE
Fix alpha filter cutting the country name on RTL mode

### DIFF
--- a/src/CountryList.tsx
+++ b/src/CountryList.tsx
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 5,
   },
   itemCountryName: {
-    width: '90%',
+    width: '88%',
   },
   list: {
     flex: 1,


### PR DESCRIPTION
Fix a very little css style, country name is cutting on small pixels devices on RTL mode.