### PR TITLE
Fixed search issue: wrong results returned from cached data

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "modal-react-native-web": "0.2.0",
     "node-emoji": "1.10.0",
     "prop-types": "15.7.2",
-    "react-async-hook": "3.6.1"
+    "react-async-hook": "3.6.1",
+    "lodash.isequal": "4.5.0"
   },
   "devDependencies": {
     "@types/jest": "24.0.17",

--- a/src/CountryService.ts
+++ b/src/CountryService.ts
@@ -9,6 +9,7 @@ import {
   Subregion,
 } from './types'
 import Fuse from 'fuse.js'
+import isEqual from 'lodash.isequal'
 
 const imageJsonUrl =
   'https://xcarpentier.github.io/react-native-country-picker-modal/countries/'
@@ -200,7 +201,7 @@ export const search = (
   if (data.length === 0) {
     return []
   }
-  if (!fuse) {
+  if (!fuse || !isEqual(fuse.list, data)) {
     fuse = new Fuse<Country>(data, options)
   }
   if (filter && filter !== '') {


### PR DESCRIPTION
Having 2 or more instances of this component with different countries, 
if you search in the first instance then you search in another: it only searches in the data of the first instance

Steps to reproduce:
1- have 2 components with different `countryCodes`
2- open the first component and search for countries (behavior as expected)
3- open the second component: the displayed countries are correct - but when trying to search it only returns countries from the first component

Fixed by checking if the passed data is different from the cached one
