### PR TITLE
country/region instead of country

### DIFF
--- a/src/CountryFilter.tsx
+++ b/src/CountryFilter.tsx
@@ -41,5 +41,5 @@ export const CountryFilter = (props: CountryFilterProps) => {
 
 CountryFilter.defaultProps = {
   autoFocus: false,
-  placeholder: 'Enter country name'
+  placeholder: 'Enter country/region name'
 }


### PR DESCRIPTION
"Enter country/region name" instead of "Enter country name" so that the app is not rejected by Huawei