### PR TITLE
Bugfix CountryPicker uncleared useEffect

### DIFF
--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -161,6 +161,7 @@ export const CountryPicker = (props: CountryPickerProps) => {
   }
 
   useEffect(() => {
+    let cancel = false
     getCountriesAsync(
       withEmoji ? FlagType.EMOJI : FlagType.FLAT,
       translation,
@@ -171,8 +172,10 @@ export const CountryPicker = (props: CountryPickerProps) => {
       preferredCountries,
       withAlphaFilter
     )
-      .then(setCountries)
+      .then(countries => cancel ? null : setCountries(countries))
       .catch(console.warn)
+    
+    return () => cancel = true
   }, [translation, withEmoji])
 
   return (


### PR DESCRIPTION
Fixed a bug where setCountries might get called on unmounted component

**Reproduce**
Load and unload fast the component, and then an warning is thrown.
_"Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function."_