### PR TITLE
Add calling code picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ export default function App() {
 - `withModal?`: boolean
 - `visible?`: boolean
 - `containerButtonStyle?`: `StyleProp<ViewStyle>`
+- `callingCodePickerStyle?`: {
+  - `container?`: `StyleProp<ViewStyle>`
+  - `modal?`: `StyleProp<ViewStyle>`
+  - `titleContainer?`: `StyleProp<ViewStyle>`
+  - `titleText?`: `StyleProp<TextStyle>`
+  - `codeContainer?`: `StyleProp<ViewStyle>`
+  - `codeText?`: `StyleProp<TextStyle>`
+- }
+- `callingCodePickerTitle?`: string (`<country_name>` is the placeholder for the selected country name)
 - `renderFlagButton?`(props: (FlagButton['props'])): ReactNode ([FlagButton props](https://github.com/xcarpentier/react-native-country-picker-modal/blob/master/src/FlagButton.tsx#L73))
 - `renderCountryFilter?`(props: CountryFilter['props']): ReactNode ([CountryFilter props is TextInputProps](https://facebook.github.io/react-native/docs/textinput#props))
 - `onSelect`(country: Country): void ([Country](https://github.com/xcarpentier/react-native-country-picker-modal/blob/master/src/types.ts#L263))

--- a/src/CallingCodePicker.tsx
+++ b/src/CallingCodePicker.tsx
@@ -1,0 +1,144 @@
+import React, { useCallback, useMemo } from 'react'
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native'
+import { Country, TranslationLanguageCode } from './types'
+import { useTheme } from './CountryTheme'
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  },
+  modal: {
+    marginHorizontal: 20,
+    borderRadius: 4,
+    backgroundColor: '#ffffff',
+  },
+  titleContainer: {
+    padding: 18,
+    borderColor: 'rgba(0, 0, 0, 0.4)',
+    borderWidth: 0,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: 16,
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+  codeContainer: {
+    borderColor: 'rgba(0, 0, 0, 0.1)',
+    borderWidth: 0,
+    borderBottomWidth: 1,
+  },
+  codeButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+  },
+  codeText: { fontSize: 16, textAlign: 'center' },
+})
+
+interface CallingCodePickerProps {
+  title?: string
+  country?: Country
+  translation?: TranslationLanguageCode
+  style?: {
+    container?: StyleProp<ViewStyle>
+    modal?: StyleProp<ViewStyle>
+    titleContainer?: StyleProp<ViewStyle>
+    titleText?: StyleProp<TextStyle>
+    codeContainer?: StyleProp<ViewStyle>
+    codeText?: StyleProp<TextStyle>
+  }
+  onSelect?(country: Country): void
+}
+
+export const CallingCodePicker = (props: CallingCodePickerProps) => {
+  const { title, country, translation, style, onSelect } = props
+  const { fontFamily } = useTheme()
+
+  const handlePress = useCallback(
+    (code: string) => {
+      if (onSelect && country) {
+        onSelect({
+          ...country,
+          callingCode: [
+            code,
+            ...country.callingCode.filter(_code => _code !== code),
+          ],
+        })
+      }
+    },
+    [onSelect],
+  )
+
+  const countryName: string = useMemo(() => {
+    if (!country) {
+      return ''
+    }
+    if (typeof country.name === 'object') {
+      return translation ? country.name[translation] : ''
+    }
+    return country.name
+  }, [country, translation])
+
+  const parsedTitle: string = useMemo(() => {
+    if (!country) {
+      return ''
+    }
+    if (title) {
+      return title.replace(/<country_name>/g, countryName)
+    }
+    return `Select a Calling Code for\n${countryName}`
+  }, [country, title, countryName])
+
+  if (!country) {
+    return null
+  }
+
+  return (
+    <>
+      <View style={[styles.container, style && style.container]}>
+        <View style={[styles.modal, style && style.modal]}>
+          <View style={[styles.titleContainer, style && style.titleContainer]}>
+            <Text
+              numberOfLines={2}
+              ellipsizeMode='tail'
+              style={[styles.title, { fontFamily }, style && style.titleText]}
+            >
+              {parsedTitle}
+            </Text>
+          </View>
+          {country.callingCode.map(code => (
+            <View
+              style={[styles.codeContainer, style && style.codeContainer]}
+              key={code}
+            >
+              <TouchableOpacity
+                style={[styles.codeButton]}
+                onPress={() => handlePress(code)}
+              >
+                <Text style={[styles.codeText, style && style.codeText]}>
+                  +{code}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      </View>
+    </>
+  )
+}

--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -164,7 +164,11 @@ export const CountryPicker = (props: CountryPickerProps) => {
     }
   }
   const onClose = () => {
-    setState({ ...state, filter: '', visible: false })
+    setState(prevState => ({
+      ...prevState,
+      filter: '',
+      visible: false,
+    }))
     if (handleClose) {
       handleClose()
     }
@@ -179,36 +183,37 @@ export const CountryPicker = (props: CountryPickerProps) => {
       onSelect(country)
       onClose()
       if (country.callingCode[0]) {
-        setState({
-          ...state,
+        setState(prevState => ({
+          ...prevState,
           callingCodePicker: {
-            ...state.callingCodePicker,
-            callingCode: country.callingCode[0],
+            ...prevState.callingCodePicker,
+            visible: false,
+            callingCode: country.callingCode[0] || '',
           },
-        })
+        }))
       }
       return
     }
-    setState({
-      ...state,
+    setState(prevState => ({
+      ...prevState,
       callingCodePicker: {
-        ...state.callingCodePicker,
+        ...prevState.callingCodePicker,
         visible: true,
         country,
       },
-    })
+    }))
   }
   const handleCallingCodeSelect = (country: Country) => {
     onSelect(country)
     onClose()
-    setState({
-      ...state,
+    setState(prevState => ({
+      ...prevState,
       callingCodePicker: {
-        ...state.callingCodePicker,
+        ...prevState.callingCodePicker,
         visible: false,
-        callingCode: country.callingCode[0],
+        callingCode: country.callingCode[0] || '',
       },
-    })
+    }))
   }
   const onFocus = () => setState({ ...state, filterFocus: true })
   const onBlur = () => setState({ ...state, filterFocus: false })

--- a/src/FlagButton.tsx
+++ b/src/FlagButton.tsx
@@ -7,7 +7,7 @@ import {
   ViewStyle,
   TextProps,
 } from 'react-native'
-import { CountryCode } from './types'
+import { CallingCode, CountryCode } from './types'
 import { Flag } from './Flag'
 import { useContext } from './CountryContext'
 import { CountryText } from './CountryText'
@@ -35,6 +35,7 @@ const styles = StyleSheet.create({
 type FlagWithSomethingProp = Pick<
   FlagButtonProps,
   | 'countryCode'
+  | 'callingCode'
   | 'withEmoji'
   | 'withCountryNameButton'
   | 'withCurrencyButton'
@@ -51,6 +52,7 @@ const FlagWithSomething = memo(
   ({
     allowFontScaling,
     countryCode,
+    callingCode,
     withEmoji,
     withCountryNameButton,
     withCurrencyButton,
@@ -63,9 +65,8 @@ const FlagWithSomething = memo(
     const [state, setState] = useState({
       countryName: '',
       currency: '',
-      callingCode: '',
     })
-    const { countryName, currency, callingCode } = state
+    const { countryName, currency } = state
     useEffect(() => {
       if (countryCode) {
         getCountryInfoAsync({ countryCode, translation })
@@ -118,6 +119,7 @@ export interface FlagButtonProps {
   withFlagButton?: boolean
   containerButtonStyle?: StyleProp<ViewStyle>
   countryCode?: CountryCode
+  callingCode?: CallingCode
   placeholder: string
   onOpen?(): void
 }
@@ -130,6 +132,7 @@ export const FlagButton = ({
   withCurrencyButton,
   withFlagButton,
   countryCode,
+  callingCode,
   containerButtonStyle,
   onOpen,
   placeholder,
@@ -148,6 +151,7 @@ export const FlagButton = ({
           {...{
             allowFontScaling,
             countryCode,
+            callingCode,
             withEmoji,
             withCountryNameButton,
             withCallingCodeButton,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,13 @@ import {
 import { CountryProvider, DEFAULT_COUNTRY_CONTEXT } from './CountryContext'
 import { ThemeProvider, DEFAULT_THEME, Theme } from './CountryTheme'
 import { CountryFilterProps } from './CountryFilter'
-import { StyleProp, ViewStyle, ModalProps, FlatListProps } from 'react-native'
+import {
+  StyleProp,
+  ViewStyle,
+  ModalProps,
+  FlatListProps,
+  TextStyle,
+} from 'react-native'
 import { CountryPicker } from './CountryPicker'
 
 interface Props {
@@ -42,6 +48,15 @@ interface Props {
   disableNativeModal?: boolean
   visible?: boolean
   containerButtonStyle?: StyleProp<ViewStyle>
+  callingCodePickerStyle?: {
+    container?: StyleProp<ViewStyle>
+    modal?: StyleProp<ViewStyle>
+    titleContainer?: StyleProp<ViewStyle>
+    titleText?: StyleProp<TextStyle>
+    codeContainer?: StyleProp<ViewStyle>
+    codeText?: StyleProp<TextStyle>
+  }
+  callingCodePickerTitle?: string
   renderFlagButton?(props: FlagButtonProps): ReactNode
   renderCountryFilter?(props: CountryFilterProps): ReactNode
   onSelect(country: Country): void


### PR DESCRIPTION
Some countries have multiple calling codes and users are unable to choose the right calling code for their numbers.

Users can now choose their calling code from the `CallingCodePicker` modal after they select a country.

<img src="https://i.imgur.com/XlT8f78.png" width="320" />