### PR TITLE
Don't invert the flag colours

### DIFF
--- a/src/Flag.tsx
+++ b/src/Flag.tsx
@@ -86,9 +86,13 @@ export const Flag = ({
   withFlagButton ? (
     <View style={styles.container}>
       {withEmoji ? (
-        <EmojiFlag {...{ countryCode, flagSize }} />
+        <EmojiFlag
+          {...{ countryCode, flagSize, accessibilityIgnoresInvertColors: true }}
+        />
       ) : (
-        <ImageFlag {...{ countryCode, flagSize }} />
+        <ImageFlag
+          {...{ countryCode, flagSize, accessibilityIgnoresInvertColors: true }}
+        />
       )}
     </View>
   ) : null


### PR DESCRIPTION
Adds the `accessibilityIgnoresInvertColors` prop to the flags to stop them from getting inverted if the Smart Invert accessibility option is switched on iOS.

| Before | After |
|---|---|
|  ![Screenshot of the country picker before the prop was added](https://user-images.githubusercontent.com/43314/138864556-a6b6f3ab-f664-4a57-a2c4-25f3ff3fa2a7.png) | ![Screenshot of the country picker after the prop was added](https://user-images.githubusercontent.com/43314/138864538-fa3bf131-d6a2-4e95-942c-5bb96fa54bd8.png) |