### PR TITLE
Add support for container style in Flag component

### DIFF
--- a/src/Flag.tsx
+++ b/src/Flag.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   View,
   ActivityIndicator,
+  StyleProp
 } from 'react-native'
 
 const styles = StyleSheet.create({
@@ -39,7 +40,8 @@ interface FlagType {
   countryCode: CountryCode
   withEmoji?: boolean
   withFlagButton?: boolean
-  flagSize: number
+  flagSize: number,
+  containerStyle: StyleProp<ViewStyle>
 }
 
 const ImageFlag = memo(({ countryCode, flagSize }: FlagType) => {
@@ -82,9 +84,10 @@ export const Flag = ({
   withEmoji,
   withFlagButton,
   flagSize,
+  containerStyle
 }: FlagType) =>
   withFlagButton ? (
-    <View style={styles.container}>
+    <View style={[styles.container, containerStyle]}>
       {withEmoji ? (
         <EmojiFlag {...{ countryCode, flagSize }} />
       ) : (


### PR DESCRIPTION
I was working on responsive design in react native. I've used ```flagSize``` prop to modify the font size of the flag. I came across this design when making the font size responsive:

![image](https://user-images.githubusercontent.com/12479978/146378863-021854fa-5f09-4abd-8f55-4cc675984fb0.png)

While debugging this design issue, I found out that a style is being applied to the container of the ```Flag``` component. The style is as follows:
(https://github.com/xcarpentier/react-native-country-picker-modal/blob/master/src/Flag.tsx#L16)
```js
container: {
        justifyContent: 'center',
        alignItems: 'center',
        width: 30,
        marginRight: 10,
    }
```

The ```width``` mentioned here is the cause of this UI issue. To solve this, I would override the ```width``` property with my own. Hence, I've introduced the ```containerStyle``` prop which will allow additional styles to be added to the ```View``` component encompassing the Flag UI.

For example, by using the implementation in my PR, I can create a component like this:
```js
<Flag
    countryCode={props.countryCode}
    flagSize={useScaledResponsiveFontSize(18)}
    containerStyle={{
        width: useScaledResponsiveFontSize(25)
    }}
/>
```

This will append my styles to the ```View``` container styles and solve the problem.
Following is the UI after using this solution:

![image](https://user-images.githubusercontent.com/12479978/146379999-df22fe57-aab2-423d-ba6b-a910c8dd9537.png)
