### PR TITLE
Extend CountryPickerProps to fix missing types

### DIFF
--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -40,7 +40,7 @@ const renderFilter = (
     <CountryFilter {...props} />
   )
 
-interface CountryPickerProps {
+export interface CountryPickerProps {
   allowFontScaling?: boolean
   countryCode?: CountryCode
   region?: Region
@@ -178,7 +178,7 @@ export const CountryPicker = (props: CountryPickerProps) => {
     )
       .then(countries => cancel ? null : setCountries(countries))
       .catch(console.warn)
-    
+
     return () => cancel = true
   }, [translation, withEmoji])
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,52 +1,14 @@
-import React, { ReactNode } from 'react'
-import { FlagButtonProps } from './FlagButton'
+import React from 'react'
 import {
   TranslationLanguageCode,
-  CountryCode,
-  Country,
-  Region,
-  Subregion,
 } from './types'
 import { CountryProvider, DEFAULT_COUNTRY_CONTEXT } from './CountryContext'
 import { ThemeProvider, DEFAULT_THEME, Theme } from './CountryTheme'
-import { CountryFilterProps } from './CountryFilter'
-import { StyleProp, ViewStyle, ModalProps, FlatListProps } from 'react-native'
-import { CountryPicker } from './CountryPicker'
+import { CountryPicker, CountryPickerProps } from './CountryPicker'
 
-interface Props {
-  allowFontScaling?: boolean
-  countryCode: CountryCode
-  region?: Region
-  subregion?: Subregion
-  countryCodes?: CountryCode[]
-  excludeCountries?: CountryCode[]
-  preferredCountries?: CountryCode[]
+interface Props extends CountryPickerProps {
   theme?: Theme
   translation?: TranslationLanguageCode
-  modalProps?: ModalProps
-  filterProps?: CountryFilterProps
-  flatListProps?: FlatListProps<Country>
-  placeholder?: string
-  withAlphaFilter?: boolean
-  withCallingCode?: boolean
-  withCurrency?: boolean
-  withEmoji?: boolean
-  withCountryNameButton?: boolean
-  withCurrencyButton?: boolean
-  withCallingCodeButton?: boolean
-  withCloseButton?: boolean
-  withFlagButton?: boolean
-  withFilter?: boolean
-  withFlag?: boolean
-  withModal?: boolean
-  disableNativeModal?: boolean
-  visible?: boolean
-  containerButtonStyle?: StyleProp<ViewStyle>
-  renderFlagButton?(props: FlagButtonProps): ReactNode
-  renderCountryFilter?(props: CountryFilterProps): ReactNode
-  onSelect(country: Country): void
-  onOpen?(): void
-  onClose?(): void
 }
 
 const Main = ({ theme, translation, ...props }: Props) => {


### PR DESCRIPTION
Some of the CountryPicker props are missing from the type definition. e.g. `closeButtonStyle` and `closeButtonImage`:
<img width="848" alt="Screenshot 2022-02-28 at 16 16 35" src="https://user-images.githubusercontent.com/2145641/156018291-064daa91-503d-4690-a1cc-15da7ccb13d7.png">

Instead of defining the types twice (`Props` in `src/index.tsx` and `CountryPickerProps` in `src/CountryPicker.tsx` we can extend `CountryPickerProps` and add the `theme` and `translation` prop types:

```
interface Props extends CountryPickerProps {
  theme?: Theme
  translation?: TranslationLanguageCode
}
```  
