### PR TITLE
Fix: Issue#477 Emoji Flag get cropped when passing flagSize=100

### DIFF
--- a/src/Flag.tsx
+++ b/src/Flag.tsx
@@ -69,7 +69,7 @@ const EmojiFlag = memo(({ countryCode, flagSize }: FlagType) => {
   }
   return (
     <Text
-      style={[styles.emojiFlag, { fontSize: flagSize }]}
+      style={[styles.emojiFlag, { width: flagSize }, { fontSize: flagSize }]}
       allowFontScaling={false}
     >
       <Emoji {...{ name: asyncResult.result! }} />


### PR DESCRIPTION
References Issue#477

Where emoji flag was getting cropped when `flagSize` is 100 or more than 10.  Giving a width style to `EmojiFlag` component fixes it.