### PR TITLE
fix(service): fixing sorting when using preferred countries

### DIFF
--- a/src/CountryService.ts
+++ b/src/CountryService.ts
@@ -136,7 +136,9 @@ export const getCountriesAsync = async (
   }
 
   if (preferredCountries && !withAlphaFilter) {
-    const newCountryCodeList = [...preferredCountries, ...CountryCodeList.filter(code => !preferredCountries.includes(code))]
+    // sorting before filtering by preferred countries to avoid the list not being sorted alphabetically
+    const sortedCountryCodeList = [...CountryCodeList].sort()
+    const newCountryCodeList = [...preferredCountries, ...sortedCountryCodeList.filter(code => !preferredCountries.includes(code))]
 
     const countries = newCountryCodeList.filter(isCountryPresent(countriesRaw))
     .map((cca2: CountryCode) => ({


### PR DESCRIPTION
When using the `preferredCountries` prop, the alphabetic sorting is not applied, you can notice by seeing for example Hong Hong at the bottom of the list.

| Before  | After |
| ---------- | ---------- |
| ![Simulator Screen Shot - iPhone 13 - 2022-09-21 at 11 15 08](https://user-images.githubusercontent.com/20783123/191465676-63440a49-adc8-484e-8446-409183e5e27b.png) | ![After](https://user-images.githubusercontent.com/20783123/191465344-32b011c3-e200-4d41-a433-c3a09eee292c.gif) |
