### PR TITLE
feat: Added UK in the CountryCode list

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -248,7 +248,8 @@ export const CountryCodeList = [
   'ZW',
   'KI',
   'HK',
-  'AX'
+  'AX',
+  'UK'
 ] as const
 
 export type CountryCode = typeof CountryCodeList[number]


### PR DESCRIPTION
Hi,
I'm using a library called react-native-phone-input which is based on this library.
I encountered a problem when trying to set the default code to the UK (which wasn't in the list).

![image](https://github.com/xcarpentier/react-native-country-picker-modal/assets/55291600/1f0a9489-a570-4ce3-8314-114bcac6dba8)

