### PR TITLE
fix: use SafeAreaView from react-native-safe-area-context to prevent crash on RN >0.80

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "@callstack/react-theme-provider": "3.0.9",
     "fuse.js": "3.4.5",
     "node-emoji": "1.11.0",
-    "react-async-hook": "4.0.0"
+    "react-async-hook": "4.0.0",
+    "react-native-safe-area-context": "^4.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/src/CountryModal.tsx
+++ b/src/CountryModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { ModalProps, SafeAreaView, StyleSheet, Platform } from 'react-native'
+import { ModalProps, StyleSheet, Platform } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { AnimatedModal } from './AnimatedModal'
 import { Modal } from './Modal'
 import { useTheme } from './CountryTheme'


### PR DESCRIPTION
 Switches SafeAreaView usage from react-native to react-native-safe-area-context. The react-native SafeAreaView crashes apps on RN >0.80, and logs recommend switching to the safe-area-context variant. This fixes the crash and follows best practices for newer React Native versions.